### PR TITLE
Save last visited sensor id in client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ source 'https://rails-assets.org' do
   gem 'rails-assets-leaflet', '1.0.0.beta.2'
   # It's an extension for leaflet.js to deal with ArcGIS feature layer servers
   gem 'rails-assets-esri-leaflet', '~> 1.0.0'
+  gem 'rails-assets-js-cookie', '~> 2.1.0'
 end
 
 # Helps with translating strings directly in js/cs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,7 @@ GEM
       railties (= 4.2.5)
       sprockets-rails
     rails-assets-esri-leaflet (1.0.1)
+    rails-assets-js-cookie (2.1.0)
     rails-assets-leaflet (1.0.0.beta.2)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
@@ -291,6 +292,7 @@ DEPENDENCIES
   quiet_assets
   rails (~> 4.2.0)
   rails-assets-esri-leaflet (~> 1.0.0)!
+  rails-assets-js-cookie (~> 2.1.0)!
   rails-assets-leaflet (= 1.0.0.beta.2)!
   rails_12factor
   rspec-rails (~> 3.0)

--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -6,6 +6,7 @@
 #= require leaflet
 #= require esri-leaflet
 #= require js-routes
+#= require js-cookie
 #= require leaflet-heatmap
 #= require heatmap
 #= require highcharts

--- a/app/assets/javascripts/config.js.erb
+++ b/app/assets/javascripts/config.js.erb
@@ -23,14 +23,20 @@ if (!this.Config) {
   I18n.defaultLocale = "<%= I18n.default_locale %>";
 
   this.Config.set = function(key, value) {
-    if (window.localStorage) {
-      window.localStorage.setItem("config." + key, value);
-    }
+    key = "config." + key;
+
+    if (window.localStorage)
+      window.localStorage.setItem(key, value);
+    else if (window.Cookies)
+      window.Cookies.set(key, value, { expires: 365 });
   }
 
   this.Config.get = function(key) {
-    if (window.localStorage) {
-      return window.localStorage.getItem("config." + key);
-    }
+    key = "config." + key;
+
+    if (window.localStorage)
+      return window.localStorage.getItem(key);
+    else if (window.Cookies)
+      return window.Cookies.get(key);
   }
 }

--- a/app/assets/javascripts/config.js.erb
+++ b/app/assets/javascripts/config.js.erb
@@ -31,12 +31,15 @@ if (!this.Config) {
       window.Cookies.set(key, value, { expires: 365 });
   }
 
-  this.Config.get = function(key) {
+  this.Config.get = function(key, converter) {
     key = "config." + key;
 
     if (window.localStorage)
-      return window.localStorage.getItem(key);
+      value = window.localStorage.getItem(key);
     else if (window.Cookies)
-      return window.Cookies.get(key);
+      value = window.Cookies.get(key);
+
+    if (value)
+      return converter ? converter(value) : value;
   }
 }

--- a/app/assets/javascripts/config.js.erb
+++ b/app/assets/javascripts/config.js.erb
@@ -21,4 +21,16 @@ if (!this.Config) {
     '&copy; <a href="http://cartodb.com/attributions">CartoDB</a>';
 
   I18n.defaultLocale = "<%= I18n.default_locale %>";
+
+  this.Config.set = function(key, value) {
+    if (window.localStorage) {
+      window.localStorage.setItem("config." + key, value);
+    }
+  }
+
+  this.Config.get = function(key) {
+    if (window.localStorage) {
+      return window.localStorage.getItem("config." + key);
+    }
+  }
 }

--- a/app/assets/javascripts/dispatcher.js.coffee
+++ b/app/assets/javascripts/dispatcher.js.coffee
@@ -24,7 +24,7 @@ class Dispatcher
   initSmogMap: ->
     console.log 'INIT [Dispatcher]: initializing Smog Map component'
     if $('#smog-map').length > 0
-      new SmogMap
+      new SmogMap(Config)
 
   switchTabs: (targetTab) ->
     console.log "INIT [Dispatcher]: switching left section to #{targetTab}"

--- a/app/assets/javascripts/smog_map.js.coffee
+++ b/app/assets/javascripts/smog_map.js.coffee
@@ -39,9 +39,9 @@ class @SmogMap
           on 'click', (sensor) =>
             if window.isDeviceClass('xs')
               window.toggleSidebar () =>
-                SmogMap.loadSensor(sensor)
+                @loadSensor(sensor)
             else
-              SmogMap.loadSensor(sensor)
+              @loadSensor(sensor)
         sensorMarker.dbId = sensor.id
 
     $('#zoom-out-button').on 'click', =>
@@ -51,7 +51,9 @@ class @SmogMap
       bounds = L.latLngBounds southWest, northEast
       window.smogMap.fitBounds bounds
 
-  @loadSensor: (sensor) ->
+  loadSensor: (sensor) ->
     $.get 'sensors/' + sensor.target.dbId, (data) ->
       $('#sensors-tab').html data
       $('#left-section a[href="#sensors-tab"]').tab 'show'
+
+    @config.set("sensor.id", sensor.target.dbId)

--- a/app/assets/javascripts/smog_map.js.coffee
+++ b/app/assets/javascripts/smog_map.js.coffee
@@ -18,6 +18,18 @@ class @SmogMap
       attribution: config.OSM_ATTRIBUTION + ', ' + config.CDB_ATTRIBUTION
     }).addTo window.smogMap
 
+    @initSensors()
+
+    $('#zoom-out-button').on 'click', =>
+      # Zoom the map to proper bounds
+      southWest = L.latLng config.MAX_BOUNDS_SOUTH, config.MAX_BOUNDS_WEST
+      northEast = L.latLng config.MAX_BOUNDS_NORTH, config.MAX_BOUNDS_EAST
+      bounds = L.latLngBounds southWest, northEast
+      window.smogMap.fitBounds bounds
+
+  initSensors: ->
+    window.markerLayer = L.layerGroup()
+
     bigIcon = L.icon
       iconUrl: 'assets/images/marker-icon-2x.png'
       iconAnchor:   [20, 80] # point of the icon which will correspond to marker's location
@@ -27,7 +39,8 @@ class @SmogMap
       iconSize:     [25, 25] # size of the icon
       iconAnchor:   [13, 13] # point of the icon which will correspond to marker's location
 
-    window.markerLayer = L.layerGroup()
+    lastSensorId = @config.get("sensor.id", Number)
+
     $.get 'sensors.json', (data) =>
       $(data).each (i, sensor) =>
         sensorMarker = if sensor.id == 1000
@@ -42,14 +55,11 @@ class @SmogMap
                 @loadSensor(sensor)
             else
               @loadSensor(sensor)
+
         sensorMarker.dbId = sensor.id
 
-    $('#zoom-out-button').on 'click', =>
-      # Zoom the map to proper bounds
-      southWest = L.latLng config.MAX_BOUNDS_SOUTH, config.MAX_BOUNDS_WEST
-      northEast = L.latLng config.MAX_BOUNDS_NORTH, config.MAX_BOUNDS_EAST
-      bounds = L.latLngBounds southWest, northEast
-      window.smogMap.fitBounds bounds
+        if lastSensorId == sensor.id
+          window.smogMap.setView([sensor['lat'], sensor['long']], 14)
 
   loadSensor: (sensor) ->
     $.get 'sensors/' + sensor.target.dbId, (data) ->

--- a/app/assets/javascripts/smog_map.js.coffee
+++ b/app/assets/javascripts/smog_map.js.coffee
@@ -1,5 +1,7 @@
 class @SmogMap
-  constructor: ->
+  constructor: (config) ->
+    @config = config
+
     L.Icon.Default.imagePath = 'assets/images'
 
     $('#smog-map').css('min-height', window.innerHeight - 50)
@@ -12,8 +14,8 @@ class @SmogMap
       zoomOutTitle: I18n.t('map.zoom_out')
     ).addTo window.smogMap
 
-    L.tileLayer(Config.CDB_TILE_URL,{
-      attribution: Config.OSM_ATTRIBUTION + ', ' + Config.CDB_ATTRIBUTION
+    L.tileLayer(config.CDB_TILE_URL,{
+      attribution: config.OSM_ATTRIBUTION + ', ' + config.CDB_ATTRIBUTION
     }).addTo window.smogMap
 
     bigIcon = L.icon
@@ -44,8 +46,8 @@ class @SmogMap
 
     $('#zoom-out-button').on 'click', =>
       # Zoom the map to proper bounds
-      southWest = L.latLng Config.MAX_BOUNDS_SOUTH, Config.MAX_BOUNDS_WEST
-      northEast = L.latLng Config.MAX_BOUNDS_NORTH, Config.MAX_BOUNDS_EAST
+      southWest = L.latLng config.MAX_BOUNDS_SOUTH, config.MAX_BOUNDS_WEST
+      northEast = L.latLng config.MAX_BOUNDS_NORTH, config.MAX_BOUNDS_EAST
       bounds = L.latLngBounds southWest, northEast
       window.smogMap.fitBounds bounds
 


### PR DESCRIPTION
Fixes #9, #20:

* enhance `Config` with ability to store settings in local storage or cookies
* store id of last clicked sensor
* initially center map on last selected sensor