### PR TITLE
Add docker to simplify local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ruby:2.3.0
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+RUN mkdir /smogmapper
+WORKDIR /smogmapper
+ADD Gemfile /smogmapper/Gemfile
+ADD Gemfile.lock /smogmapper/Gemfile.lock
+RUN bundle install
+ADD . /smogmapper

--- a/config/database.yml
+++ b/config/database.yml
@@ -24,10 +24,16 @@ default: &default
 development:
   <<: *default
   database: smogmapper_development
+  username: <%= ENV['SMOGMAPPER_DB_USERNAME'] %>
+  password: <%= ENV['SMOGMAPPER_DB_PASSWORD'] %>
+  host: <%= ENV['SMOGMAPPER_DB_HOST'] %>
 
 test:
   <<: *default
   database: smogmapper_test
+  username: <%= ENV['SMOGMAPPER_DB_USERNAME'] %>
+  password: <%= ENV['SMOGMAPPER_DB_PASSWORD'] %>
+  host: <%= ENV['SMOGMAPPER_DB_HOST'] %>
 
 production:
   <<: *default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+db:
+  image: postgres
+web:
+  build: .
+  command: bundle exec rails s -p 3000 -b '0.0.0.0'
+  volumes:
+    - .:/smogmapper
+  ports:
+    - "3000:3000"
+  environment:
+    SMOGMAPPER_DB_USERNAME: postgres
+    SMOGMAPPER_DB_HOST: db
+  links:
+    - db


### PR DESCRIPTION
Thanks to docker developer does not have ruby, postgresql installed, just docker and docker-compose, next following command need to be executed:
  - `docker-compose build` (only for first time and after Gemfile is changed)
  - `docker-compose up`
  - `docker-compose run web rake db:create db:migrate db:seed`

As a result smogmapper will be started and will be accessible on port 3000.

If you want to run specs or guard invoke:
  - `docker-compose run web rspec`
  - `docker-compose run web guard`

See https://docs.docker.com/compose/rails/ for details.